### PR TITLE
DeepFreeze Compatibility fixes

### DIFF
--- a/ShipManifest/SMAddon.cs
+++ b/ShipManifest/SMAddon.cs
@@ -392,7 +392,7 @@ namespace ShipManifest
             {
                 //Check for DeepFreezer full. if full, abort handling Xfer.
                 if (DFInterface.IsDFInstalled && action.to.Modules.Contains("DeepFreezer"))
-                    if (((IDeepFreezer)action.to.Modules["DeepFreezer"]).DFIPartFull)
+                    if (((IDeepFreezer)action.to.Modules["DeepFreezer"]).DFIFreezerSpace == 0)
                         return;
 
                 // If we are here, then we want to override the Stock Xfer...

--- a/ShipManifest/SMAddon.cs
+++ b/ShipManifest/SMAddon.cs
@@ -833,6 +833,28 @@ namespace ShipManifest
                     WindowTransfer.xferToolTip = "Source and Target Part are the same.\r\nUse Move Kerbal (>>) instead.";
                     return results;
                 }
+                // If one of the parts is a DeepFreeze part and no crew are showing in protoModuleCrew, check it isn't full of frozen Kerbals. 
+                // This is to prevent SM from Transferring crew into a DeepFreeze part that is full of frozen kerbals.
+                // If there is just one spare seat or seat taken by a Thawed Kerbal that is OK because SM will just transfer them into the empty
+                // seat or swap them with a thawed Kerbal.
+                IDeepFreezer sourcepartFrzr = SelectedPartsSource[0].FindModuleImplementing<IDeepFreezer>();
+                IDeepFreezer targetpartFrzr = SelectedPartsTarget[0].FindModuleImplementing<IDeepFreezer>();
+                if (sourcepartFrzr != null)
+                {
+                    if (sourcepartFrzr.DFIFreezerSpace == 0)
+                    {
+                        WindowTransfer.xferToolTip = "DeepFreeze Part is full of frozen kerbals.\r\nCannot Xfer until some are thawed.";
+                        return results;
+                    }
+                }
+                if (targetpartFrzr != null)
+                {
+                    if (targetpartFrzr.DFIFreezerSpace == 0)
+                    {
+                        WindowTransfer.xferToolTip = "DeepFreeze Part is full of frozen kerbals.\r\nCannot Xfer until some are thawed.";
+                        return results;
+                    }
+                }
 
                 // Are there kerbals to move?
                 if (SelectedPartsSource[0].protoModuleCrew.Count == 0)

--- a/ShipManifest/TransferCrew.cs
+++ b/ShipManifest/TransferCrew.cs
@@ -267,7 +267,7 @@ namespace ShipManifest
                         foreach (InternalSeat seat in ToPart.internalModel.seats)
                         {
                             // This supports DeepFreeze frozen kerbals...
-                            if (seat.kerbalRef != null)
+                            if (seat.kerbalRef != null && seat.kerbalRef.protoCrewMember.rosterStatus != ProtoCrewMember.RosterStatus.Dead)
                             {
                                 ToSeat = seat;
                                 break;

--- a/ShipManifest/WindowTransfer.cs
+++ b/ShipManifest/WindowTransfer.cs
@@ -5,6 +5,7 @@ using System.Text;
 using UnityEngine;
 using HighlightingSystem;
 using ConnectedLivingSpace;
+using DF;
 
 namespace ShipManifest
 {
@@ -528,6 +529,53 @@ namespace ShipManifest
                     GUI.enabled = true;
                     GUILayout.EndHorizontal();
                 }
+                // Cater for DeepFreeze Continued... parts - list frozen kerbals
+                if (DF.DFInterface.IsDFInstalled)
+                {                    
+                    try
+                    {
+                        IDeepFreezer sourcepartFrzr = SelectedPartsFrom[0].FindModuleImplementing<IDeepFreezer>();
+                        if (sourcepartFrzr.DFIStoredCrewList.Count > 0)
+                        {                            
+                            DF.IDFInterface DFOjbect = DF.DFInterface.GetFrozenKerbals();
+                            foreach (DF.FrznCrewMbr frzncrew in sourcepartFrzr.DFIStoredCrewList)
+                            {
+                                GUILayout.BeginHorizontal();
+                                GUI.enabled = false;
+                                if (GUILayout.Button(new GUIContent(">>", "Move Kerbal to another seat within Part"), SMStyle.ButtonStyle, GUILayout.Width(15), GUILayout.Height(20)))
+                                {
+                                    ToolTip = "";                                    
+                                }
+                                if (Event.current.type == EventType.Repaint && ShowToolTips == true)
+                                {
+                                    Rect rect = GUILayoutUtility.GetLastRect();
+                                    ToolTip = SMToolTips.SetActiveTooltip(rect, WindowTransfer.Position, GUI.tooltip, ref ToolTipActive, xOffset, yOffset - scrollPosition.y);
+                                }
+
+                                string trait = DFOjbect.FrozenKerbals[frzncrew.CrewName].experienceTraitName;
+                                GUILayout.Label(string.Format("  {0}", frzncrew.CrewName + " (" + trait + ")"), SMStyle.LabelStyleCyan, GUILayout.Width(190), GUILayout.Height(20));
+
+                                if (GUILayout.Button(new GUIContent("Frzn", "This Kerbal is Frozen and cannot be moved"), SMStyle.ButtonStyle, GUILayout.Width(50), GUILayout.Height(20)))
+                                {
+                                    ToolTip = "";
+                                }
+                                if (Event.current.type == EventType.Repaint && ShowToolTips == true)
+                                {
+                                    Rect rect = GUILayoutUtility.GetLastRect();
+                                    ToolTip = SMToolTips.SetActiveTooltip(rect, WindowTransfer.Position, GUI.tooltip, ref ToolTipActive, xOffset, yOffset - scrollPosition.y);
+                                }
+                                GUI.enabled = true;
+                                GUILayout.EndHorizontal();
+                            }
+                        }                                               
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.Log("Error attempting to check DeepFreeze for FrozenKerbals");
+                        Debug.Log(ex.Message);
+                        
+                    }
+                }                               
             }
         }
 

--- a/ShipManifest/WindowTransfer.cs
+++ b/ShipManifest/WindowTransfer.cs
@@ -535,38 +535,42 @@ namespace ShipManifest
                     try
                     {
                         IDeepFreezer sourcepartFrzr = SelectedPartsFrom[0].FindModuleImplementing<IDeepFreezer>();
-                        if (sourcepartFrzr.DFIStoredCrewList.Count > 0)
-                        {                                                       
-                            foreach (DF.FrznCrewMbr frzncrew in sourcepartFrzr.DFIStoredCrewList)
+                        if (sourcepartFrzr != null)
+                        {
+                            if (sourcepartFrzr.DFIStoredCrewList.Count > 0)
                             {
-                                GUILayout.BeginHorizontal();
-                                GUI.enabled = false;
-                                if (GUILayout.Button(new GUIContent(">>", "Move Kerbal to another seat within Part"), SMStyle.ButtonStyle, GUILayout.Width(15), GUILayout.Height(20)))
+                                DF.IDFInterface DFOjbect = DF.DFInterface.GetFrozenKerbals();
+                                foreach (DF.FrznCrewMbr frzncrew in sourcepartFrzr.DFIStoredCrewList)
                                 {
-                                    ToolTip = "";                                    
-                                }
-                                if (Event.current.type == EventType.Repaint && ShowToolTips == true)
-                                {
-                                    Rect rect = GUILayoutUtility.GetLastRect();
-                                    ToolTip = SMToolTips.SetActiveTooltip(rect, WindowTransfer.Position, GUI.tooltip, ref ToolTipActive, xOffset, yOffset - scrollPosition.y);
-                                }
+                                    GUILayout.BeginHorizontal();
+                                    GUI.enabled = false;
+                                    if (GUILayout.Button(new GUIContent(">>", "Move Kerbal to another seat within Part"), SMStyle.ButtonStyle, GUILayout.Width(15), GUILayout.Height(20)))
+                                    {
+                                        ToolTip = "";
+                                    }
+                                    if (Event.current.type == EventType.Repaint && ShowToolTips == true)
+                                    {
+                                        Rect rect = GUILayoutUtility.GetLastRect();
+                                        ToolTip = SMToolTips.SetActiveTooltip(rect, WindowTransfer.Position, GUI.tooltip, ref ToolTipActive, xOffset, yOffset - scrollPosition.y);
+                                    }
 
-                                string trait = SMAddon.FrozenKerbals[frzncrew.CrewName].experienceTraitName;
-                                GUILayout.Label(string.Format("  {0}", frzncrew.CrewName + " (" + trait + ")"), SMStyle.LabelStyleCyan, GUILayout.Width(190), GUILayout.Height(20));
+                                    string trait = DFOjbect.FrozenKerbals[frzncrew.CrewName].experienceTraitName;
+                                    GUILayout.Label(string.Format("  {0}", frzncrew.CrewName + " (" + trait + ")"), SMStyle.LabelStyleCyan, GUILayout.Width(190), GUILayout.Height(20));
 
-                                if (GUILayout.Button(new GUIContent("Frzn", "This Kerbal is Frozen and cannot be moved"), SMStyle.ButtonStyle, GUILayout.Width(50), GUILayout.Height(20)))
-                                {
-                                    ToolTip = "";
+                                    if (GUILayout.Button(new GUIContent("Frzn", "This Kerbal is Frozen and cannot be moved"), SMStyle.ButtonStyle, GUILayout.Width(50), GUILayout.Height(20)))
+                                    {
+                                        ToolTip = "";
+                                    }
+                                    if (Event.current.type == EventType.Repaint && ShowToolTips == true)
+                                    {
+                                        Rect rect = GUILayoutUtility.GetLastRect();
+                                        ToolTip = SMToolTips.SetActiveTooltip(rect, WindowTransfer.Position, GUI.tooltip, ref ToolTipActive, xOffset, yOffset - scrollPosition.y);
+                                    }
+                                    GUI.enabled = true;
+                                    GUILayout.EndHorizontal();
                                 }
-                                if (Event.current.type == EventType.Repaint && ShowToolTips == true)
-                                {
-                                    Rect rect = GUILayoutUtility.GetLastRect();
-                                    ToolTip = SMToolTips.SetActiveTooltip(rect, WindowTransfer.Position, GUI.tooltip, ref ToolTipActive, xOffset, yOffset - scrollPosition.y);
-                                }
-                                GUI.enabled = true;
-                                GUILayout.EndHorizontal();
                             }
-                        }                                               
+                        }                                                        
                     }
                     catch (Exception ex)
                     {

--- a/ShipManifest/WindowTransfer.cs
+++ b/ShipManifest/WindowTransfer.cs
@@ -536,8 +536,7 @@ namespace ShipManifest
                     {
                         IDeepFreezer sourcepartFrzr = SelectedPartsFrom[0].FindModuleImplementing<IDeepFreezer>();
                         if (sourcepartFrzr.DFIStoredCrewList.Count > 0)
-                        {                            
-                            DF.IDFInterface DFOjbect = DF.DFInterface.GetFrozenKerbals();
+                        {                                                       
                             foreach (DF.FrznCrewMbr frzncrew in sourcepartFrzr.DFIStoredCrewList)
                             {
                                 GUILayout.BeginHorizontal();
@@ -552,7 +551,7 @@ namespace ShipManifest
                                     ToolTip = SMToolTips.SetActiveTooltip(rect, WindowTransfer.Position, GUI.tooltip, ref ToolTipActive, xOffset, yOffset - scrollPosition.y);
                                 }
 
-                                string trait = DFOjbect.FrozenKerbals[frzncrew.CrewName].experienceTraitName;
+                                string trait = SMAddon.FrozenKerbals[frzncrew.CrewName].experienceTraitName;
                                 GUILayout.Label(string.Format("  {0}", frzncrew.CrewName + " (" + trait + ")"), SMStyle.LabelStyleCyan, GUILayout.Width(190), GUILayout.Height(20));
 
                                 if (GUILayout.Button(new GUIContent("Frzn", "This Kerbal is Frozen and cannot be moved"), SMStyle.ButtonStyle, GUILayout.Width(50), GUILayout.Height(20)))


### PR DESCRIPTION
Prevent Crew Transfers into a DeepFreeze Freezer Part that is full of Frozen Kerbals.
Bug Fix to ensure Crew Transfers do not transfer Kerbals into DeepFreeze Freezer Part Seats that are taken by a Frozen Kerbal.
Enhance Crew Transfer Window - Crew Lists to Display DeepFreeze Frozen Kerbals - but you cannot Transfer them.
DFIFreezerspace == 0 indicates if freezer is full, not DFIPartFull.