### PR TITLE
Fix memory leak as reported by KSPCF

### DIFF
--- a/Source/ShipManifest/SMAddon.cs
+++ b/Source/ShipManifest/SMAddon.cs
@@ -303,6 +303,7 @@ namespace ShipManifest
         if (_smSettingsBlizzy != null)
           _smSettingsBlizzy.Destroy();
       }
+        GameEvents.onGUIApplicationLauncherDestroyed.Remove(OnGuiAppLauncherDestroyed);
     }
 
     // ReSharper disable once InconsistentNaming

--- a/Source/ShipManifest/SMAddon.cs
+++ b/Source/ShipManifest/SMAddon.cs
@@ -303,7 +303,16 @@ namespace ShipManifest
         if (_smSettingsBlizzy != null)
           _smSettingsBlizzy.Destroy();
       }
+
+      // Ensure no leftover memory leak
+      try
+      {
         GameEvents.onGUIApplicationLauncherDestroyed.Remove(OnGuiAppLauncherDestroyed);
+    }
+      catch (Exception)
+      {
+        // Do nothing
+      }
     }
 
     // ReSharper disable once InconsistentNaming


### PR DESCRIPTION
This should fix the KSPCF complain of RA memory leak that looks like
```
[LOG 18:15:46.870] [KSPCF:MemoryLeaks] A destroyed ShipManifest:SMAddon instance is owning a onGUIApplicationLauncherDestroyed GameEvents callback. No action has been taken, but unless this mod is relying on this pattern, this is likely a memory leak.
```
Same as reported in #64 
Briefly tested with a minimum KSP 1.12.3 install, the memory leak complain is gone.